### PR TITLE
Use configured gateway

### DIFF
--- a/netlify/functions/gateways.js
+++ b/netlify/functions/gateways.js
@@ -12,7 +12,7 @@ exports.handler = async (event, context) => {
         const { httpMethod } = event;
         const body = parseBody(event);
         const cfg = getConfig();
-        const paymentGateway = new PaymentGateway(cfg.ACTIVE_GATEWAY);
+        const paymentGateway = new PaymentGateway(cfg.gateway);
 
         switch (httpMethod) {
             case 'GET':


### PR DESCRIPTION
## Summary
- instantiate gateway using `cfg.gateway` so Netlify endpoints return configured provider

## Testing
- `npm test` *(fails: no test specified)*
- `node -e "const h=require('./netlify/functions/gateways').handler; h({httpMethod:'GET',path:'/.netlify/functions/gateways/current'},{}).then(r=>console.log(r.body)).catch(err=>{console.error(err); process.exit(1);});"`


------
https://chatgpt.com/codex/tasks/task_e_68b78439b5ec832a99134cf85ac6dd5a