### PR TITLE
Add robust fetch error handling across client and server

### DIFF
--- a/authProxyServer.js
+++ b/authProxyServer.js
@@ -17,7 +17,26 @@ app.post('/api/auth-token', async (req, res) => {
       body: JSON.stringify(req.body)
     });
 
-    const data = await response.json();
+    if (!response.ok) {
+      let errorData = {};
+      try {
+        errorData = await response.json();
+      } catch (e) {
+        // ignore json parse error
+      }
+      return res.status(response.status).json({
+        message: 'Falha ao autenticar com a API SyncPayments',
+        details: errorData
+      });
+    }
+
+    let data;
+    try {
+      data = await response.json();
+    } catch (err) {
+      console.error('[Auth Proxy] Erro ao interpretar resposta JSON:', err);
+      return res.status(500).json({ message: 'Resposta inválida da API SyncPayments' });
+    }
     res.status(response.status).json(data);
   } catch (error) {
     console.error('[Auth Proxy] Erro ao obter token:', error);

--- a/public/js/authProxyClient.js
+++ b/public/js/authProxyClient.js
@@ -56,16 +56,27 @@
             },
             body: JSON.stringify(authData)
         })
-        .then(response => {
+        .then(async response => {
             console.log('📥 Resposta recebida:', response.status, response.statusText);
-            
+
             if (!response.ok) {
-                return response.json().then(errorData => {
-                    throw new Error(`HTTP ${response.status}: ${errorData.message || response.statusText}`);
-                });
+                let message = 'Erro na autenticação';
+                try {
+                    const errorData = await response.json();
+                    if (errorData && errorData.message) {
+                        message = errorData.message;
+                    }
+                } catch (e) {
+                    // ignore parse error
+                }
+                throw new Error(message);
             }
-            
-            return response.json();
+
+            try {
+                return await response.json();
+            } catch (err) {
+                throw new Error('Resposta inválida do servidor');
+            }
         })
         .then(data => {
             console.log('✅ Autenticação bem-sucedida:', data);
@@ -84,7 +95,7 @@
         })
         .catch(error => {
             console.error('❌ Erro na autenticação:', error);
-            alert('❌ ERRO na autenticação:\n\n' + error.message);
+            alert('❌ Erro na autenticação: ' + (error.message || 'Falha ao processar requisição'));
         })
         .finally(() => {
             isAuthenticating = false; // Reset da flag

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -1,7 +1,18 @@
 (async function(){
   try {
     const res = await fetch('/api/config');
-    const cfg = await res.json();
+    if (!res.ok) {
+      alert('Erro ao carregar configurações iniciais');
+      return;
+    }
+    let cfg;
+    try {
+      cfg = await res.json();
+    } catch (err) {
+      console.error('Erro ao processar configurações', err);
+      alert('Resposta inválida do servidor de configurações');
+      return;
+    }
     window.APP_CONFIG = cfg;
     window.SYNCPAY_CONFIG = window.SYNCPAY_CONFIG || {};
     window.SYNCPAY_CONFIG.client_id = cfg.syncpay?.clientId;
@@ -25,5 +36,6 @@
     }
   } catch (err) {
     console.error('Erro ao carregar configurações', err);
+    alert('Erro ao carregar configurações');
   }
 })();

--- a/public/js/payment-modal.js
+++ b/public/js/payment-modal.js
@@ -395,13 +395,23 @@ class PaymentModal {
         try {
             const response = await fetch(`/api/payments/${transactionId}/status`);
             if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
+                this.showToast('Erro ao consultar status do pagamento', 'error');
+                return null;
             }
-            const result = await response.json();
+
+            let result;
+            try {
+                result = await response.json();
+            } catch (err) {
+                console.error('Erro ao processar resposta de status:', err);
+                this.showToast('Resposta inválida do servidor', 'error');
+                return null;
+            }
             const data = result.data ? (result.data.data || result.data) : null;
             return data;
         } catch (error) {
             console.error('Erro ao consultar status da transação:', error);
+            this.showToast('Erro ao consultar status do pagamento', 'error');
             return null;
         }
     }

--- a/public/js/syncpay-integration.js
+++ b/public/js/syncpay-integration.js
@@ -6,6 +6,23 @@
 (function() {
     'use strict';
 
+    async function handleResponse(response, friendlyMessage = 'Erro na requisição') {
+        if (!response.ok) {
+            let errorText = '';
+            try {
+                errorText = await response.text();
+            } catch (e) {}
+            console.error(friendlyMessage + ':', errorText);
+            throw new Error(friendlyMessage);
+        }
+        try {
+            return await response.json();
+        } catch (err) {
+            console.error('Erro ao interpretar resposta JSON:', err);
+            throw new Error('Resposta inválida do servidor');
+        }
+    }
+
     // Configuração da API
     const API_CONFIG = {
         baseUrl: 'https://api.syncpayments.com.br/api/partner/v1',
@@ -65,12 +82,7 @@
 
             console.log('📥 Resposta recebida:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(`HTTP ${response.status}: ${errorData.message || response.statusText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro na autenticação com a API');
             console.log('✅ Autenticação bem-sucedida:', data);
 
             // Armazenar token em memória
@@ -135,12 +147,7 @@
 
             console.log('📥 Resposta do saldo:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao consultar saldo');
             console.log('✅ Saldo consultado:', data);
 
             return data;
@@ -230,12 +237,7 @@
 
             console.log('📥 Resposta do cash-in:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao criar cash-in');
             console.log('✅ Cash-in criado com sucesso:', data);
 
             return data;
@@ -267,12 +269,7 @@
 
             console.log('📥 Resposta do status:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao consultar status da transação');
             console.log('✅ Status da transação consultado:', data);
 
             return data;
@@ -340,12 +337,7 @@
 
             console.log('📥 Resposta do cash-out:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao criar cash-out');
             console.log('✅ Cash-out criado com sucesso:', data);
 
             return data;
@@ -375,12 +367,7 @@
 
             console.log('📥 Resposta do perfil:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao consultar dados do parceiro');
             console.log('✅ Dados do parceiro consultados:', data);
 
             return data;
@@ -424,12 +411,7 @@
 
             console.log('📥 Resposta da listagem de webhooks:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao listar webhooks');
             console.log('✅ Webhooks listados:', data);
 
             return data;
@@ -479,12 +461,7 @@
 
             console.log('📥 Resposta da criação do webhook:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao criar webhook');
             console.log('✅ Webhook criado com sucesso:', data);
 
             return data;
@@ -538,12 +515,7 @@
 
             console.log('📥 Resposta da atualização do webhook:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao atualizar webhook');
             console.log('✅ Webhook atualizado com sucesso:', data);
 
             return data;
@@ -577,12 +549,7 @@
 
             console.log('📥 Resposta da exclusão do webhook:', response.status, response.statusText);
 
-            if (!response.ok) {
-                const errorText = await response.text();
-                throw new Error(`HTTP ${response.status}: ${response.statusText} - ${errorText}`);
-            }
-
-            const data = await response.json();
+            const data = await handleResponse(response, 'Erro ao deletar webhook');
             console.log('✅ Webhook deletado com sucesso:', data);
 
             return data;

--- a/public/js/universal-payment-integration.js
+++ b/public/js/universal-payment-integration.js
@@ -22,7 +22,17 @@
         async loadCurrentGateway() {
             try {
                 const response = await fetch('/api/gateways/current');
-                const data = await response.json();
+                if (!response.ok) {
+                    console.error('Erro ao carregar gateway atual: resposta inválida');
+                    return;
+                }
+                let data;
+                try {
+                    data = await response.json();
+                } catch (err) {
+                    console.error('Erro ao processar gateway atual:', err);
+                    return;
+                }
                 if (data.success) {
                     this.currentGateway = data.gateway;
                     console.log(`🎯 Gateway atual carregado: ${this.currentGateway}`);
@@ -76,11 +86,22 @@
                 console.log('📥 Resposta recebida:', response.status, response.statusText);
 
                 if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(`HTTP ${response.status}: ${errorData.message || response.statusText}`);
+                    let message = 'Erro ao criar transação';
+                    try {
+                        const errorData = await response.json();
+                        message = errorData.message || message;
+                    } catch (e) {
+                        // ignore parse error
+                    }
+                    throw new Error(message);
                 }
 
-                const data = await response.json();
+                let data;
+                try {
+                    data = await response.json();
+                } catch (err) {
+                    throw new Error('Resposta inválida do servidor');
+                }
                 console.log(`✅ Transação PIX criada via ${data.gateway.toUpperCase()}:`, data);
 
                 // Retornar dados padronizados independente do gateway
@@ -102,10 +123,18 @@
         async getPaymentStatus(paymentId) {
             try {
                 console.log(`🔍 Consultando status via ${this.currentGateway.toUpperCase()}...`);
-                
+
                 const response = await fetch(`/api/payments/${paymentId}/status`);
-                const data = await response.json();
-                
+                if (!response.ok) {
+                    throw new Error('Erro ao consultar status do pagamento');
+                }
+                let data;
+                try {
+                    data = await response.json();
+                } catch (err) {
+                    throw new Error('Resposta inválida do servidor');
+                }
+
                 if (data.success) {
                     return data.data;
                 } else {

--- a/server.js
+++ b/server.js
@@ -150,7 +150,13 @@ app.post('/api/auth-token', async (req, res) => {
                 });
             }
 
-            const data = await response.json();
+            let data;
+            try {
+                data = await response.json();
+            } catch (err) {
+                console.error('[Auth] Erro ao interpretar resposta JSON:', err);
+                return res.status(500).json({ message: 'Resposta inválida da API SyncPayments' });
+            }
             // console.log('✅ [DEBUG] Token gerado com sucesso');
             // console.log('📋 [DEBUG] Resposta da API:', JSON.stringify(data, null, 2));
             
@@ -207,7 +213,13 @@ app.post('/api/auth-token', async (req, res) => {
             });
         }
 
-        const data = await response.json();
+        let data;
+        try {
+            data = await response.json();
+        } catch (err) {
+            console.error('[Auth] Erro ao interpretar resposta JSON:', err);
+            return res.status(500).json({ message: 'Resposta inválida da API SyncPayments' });
+        }
         // console.log('✅ [DEBUG] Token gerado com sucesso');
         // console.log('📋 [DEBUG] Resposta da API:', JSON.stringify(data, null, 2));
         


### PR DESCRIPTION
## Summary
- check `response.ok` before parsing JSON in gateway selector and other fetch calls
- guard JSON parsing and show friendly error messages across client scripts and proxy
- add helper `handleResponse` to SyncPay integration for consistent error handling

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -s -X POST http://localhost:3000/api/gateways/switch -H 'Content-Type: application/json' -d '{"gateway":"syncpay"}'`
- `curl -s -X POST http://localhost:3000/api/payments/pix/create -H 'Content-Type: application/json' -d '{"amount":1,"description":"Test","customer_name":"Test","customer_email":"test@example.com","customer_document":"12345678901"}'`

------
https://chatgpt.com/codex/tasks/task_e_68b785afc850832ab1f942c73742aa1d