### PR TITLE
refactor: move sensitive credentials to env vars

### DIFF
--- a/README-NETLIFY.md
+++ b/README-NETLIFY.md
@@ -59,6 +59,15 @@ ENVIRONMENT=production
 WEBHOOK_SECRET=seu_webhook_secret
 ```
 
+**Descrição das chaves:**
+
+- `SYNCPAY_CLIENT_ID` – ID do cliente fornecido pela SyncPay.
+- `SYNCPAY_CLIENT_SECRET` – segredo utilizado na autenticação SyncPay.
+- `PUSHINPAY_TOKEN` – token de acesso à API PushinPay.
+- `PUSHINPAY_ENVIRONMENT` – ambiente da PushinPay (`production` ou `sandbox`).
+- `ENVIRONMENT` – ambiente geral da aplicação.
+- `WEBHOOK_SECRET` – chave para validar chamadas de webhook.
+
 ### 3. Deploy via Git (Recomendado)
 
 1. Conecte seu repositório Git à Netlify

--- a/app-config.json
+++ b/app-config.json
@@ -2,16 +2,11 @@
   "gateway": "pushinpay",
   "environment": "production",
   "generateQRCodeOnMobile": false,
-  "syncpay": {
-    "clientId": "708ddc0b-357d-4548-b158-615684caa616",
-    "clientSecret": "c08d40e5-3049-48c9-85c0-fd3cc6ca502c"
-  },
-  "pushinpay": {
-    "token": "45135|XFE5jjzsKTBY4PN1RXFIe7EISDX2DEHFukqMfii897180772"
-  },
+  "syncpay": {},
+  "pushinpay": {},
   "webhook": {
     "baseUrl": "https://privacy-sync.vercel.app",
-    "secret": "sua-chave-secreta-aqui"
+    "secret": ""
   },
   "model": {
     "name": "Arthur Lopes",

--- a/authService.js
+++ b/authService.js
@@ -1,5 +1,4 @@
 const axios = require('axios');
-const { getConfig } = require('./loadConfig');
 
 let tokenCache = { access_token: null, expires_at: null };
 
@@ -16,10 +15,9 @@ async function getToken() {
   try {
     console.log('🔐 [authService] Obtendo novo token...');
 
-    const cfg = getConfig();
     const authData = {
-      client_id: cfg.syncpay?.clientId || '',
-      client_secret: cfg.syncpay?.clientSecret || '',
+      client_id: process.env.SYNCPAY_CLIENT_ID || '',
+      client_secret: process.env.SYNCPAY_CLIENT_SECRET || '',
       '01K1259MAXE0TNRXV2C2WQN2MV': 'auth_service_' + Date.now()
     };
 

--- a/configManager.js
+++ b/configManager.js
@@ -18,13 +18,10 @@ async function main() {
   cfg.environment = await ask('Environment (production/sandbox)', cfg.environment);
   const defaultMobileQR = cfg.generateQRCodeOnMobile ? 'true' : 'false';
   cfg.generateQRCodeOnMobile = (await ask('Generate QR Code on mobile? (true/false)', defaultMobileQR)).toLowerCase() === 'true';
-  cfg.syncpay.clientId = await ask('SyncPay Client ID', cfg.syncpay.clientId);
-  cfg.syncpay.clientSecret = await ask('SyncPay Client Secret', cfg.syncpay.clientSecret);
-  cfg.pushinpay.token = await ask('PushinPay Token', cfg.pushinpay.token);
+  // Credenciais sensíveis são definidas via variáveis de ambiente
 
-  cfg.webhook = cfg.webhook || { baseUrl: 'https://seu-dominio.com', secret: 'sua-chave-secreta-aqui' };
+  cfg.webhook = cfg.webhook || { baseUrl: 'https://seu-dominio.com', secret: '' };
   cfg.webhook.baseUrl = await ask('Webhook base URL', cfg.webhook.baseUrl);
-  cfg.webhook.secret = await ask('Webhook secret', cfg.webhook.secret);
 
   cfg.redirectUrl = await ask('Redirect URL', cfg.redirectUrl || 'https://www.youtube.com/watch?v=KWiSv44OYI0&list=RDKWiSv44OYI0&start_radio=1');
 

--- a/controller/config.example.js
+++ b/controller/config.example.js
@@ -108,8 +108,8 @@ const GENERAL_CONFIG = {
  * 
  * const ACTIVE_GATEWAY = 'syncpay';
  * const SYNCPAY_CONFIG = {
- *     CLIENT_ID: '708ddc0b-357d-4548-b158-615684caa616',
- *     CLIENT_SECRET: 'c08d40e5-3049-48c9-85c0-fd3cc6ca502c',
+ *     CLIENT_ID: 'SEU_CLIENT_ID_SYNCPAY_AQUI',
+ *     CLIENT_SECRET: 'SEU_CLIENT_SECRET_SYNCPAY_AQUI',
  *     // ... outras configurações
  * };
  */
@@ -119,7 +119,7 @@ const GENERAL_CONFIG = {
  * 
  * const ACTIVE_GATEWAY = 'pushinpay';
  * const PUSHINPAY_CONFIG = {
- *     TOKEN: '36250|MPvURHE0gE6lqsPN0PtwDOUVISoLjSyvqYUvuDPi47f09b29',
+ *     TOKEN: 'SEU_TOKEN_PUSHINPAY_AQUI',
  *     // ... outras configurações
  * };
  */

--- a/controller/config.js
+++ b/controller/config.js
@@ -31,8 +31,8 @@ const ENVIRONMENT = dynamic.environment || 'production';
 // CONFIGURAÇÕES SYNCPAY
 // ============================
 const SYNCPAY_CONFIG = {
-    CLIENT_ID: dynamic.syncpay?.clientId || '',
-    CLIENT_SECRET: dynamic.syncpay?.clientSecret || '',
+    CLIENT_ID: process.env.SYNCPAY_CLIENT_ID || '',
+    CLIENT_SECRET: process.env.SYNCPAY_CLIENT_SECRET || '',
     API_BASE_URL: 'https://api.syncpayments.com.br/api/partner/v1',
     AUTH_URL: 'https://api.syncpayments.com.br/api/partner/v1/auth-token',
     TIMEOUT: 30000,
@@ -43,7 +43,7 @@ const SYNCPAY_CONFIG = {
 // CONFIGURAÇÕES PUSHINPAY
 // ============================
 const PUSHINPAY_CONFIG = {
-    TOKEN: dynamic.pushinpay?.token || '',
+    TOKEN: process.env.PUSHINPAY_TOKEN || '',
     API_BASE_URL_PROD: 'https://api.pushinpay.com.br',
     API_BASE_URL_SANDBOX: 'https://api-sandbox.pushinpay.com.br',
     TIMEOUT: 30000,
@@ -70,7 +70,7 @@ const WEBHOOK_CONFIG = {
 
     // Configurações de segurança
     VALIDATE_SIGNATURE: true,
-    SECRET_KEY: dynamic.webhook?.secret || 'sua-chave-secreta-aqui'
+    SECRET_KEY: process.env.WEBHOOK_SECRET || ''
 };
 
 // ============================

--- a/loadConfig.js
+++ b/loadConfig.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
+// Carrega variáveis de ambiente de um arquivo .env, se disponível
+require('dotenv').config();
+
 const configPath = path.join(__dirname, 'app-config.json');
 
 function getConfig() {

--- a/netlify/functions/auth-token.js
+++ b/netlify/functions/auth-token.js
@@ -1,4 +1,4 @@
-const { getConfig, successResponse, errorResponse, corsResponse, isOptionsRequest, parseBody, fetchWithTimeout } = require('./utils');
+const { successResponse, errorResponse, corsResponse, isOptionsRequest, parseBody, fetchWithTimeout } = require('./utils');
 
 exports.handler = async (event, context) => {
     // Tratar requisições CORS preflight
@@ -18,15 +18,14 @@ exports.handler = async (event, context) => {
         const extraField = body['01K1259MAXE0TNRXV2C2WQN2MV'] || 'valor';
         
         // Verificar se as credenciais estão disponíveis
-        const cfg = getConfig();
-        const clientId = cfg.syncpay?.clientId;
-        const clientSecret = cfg.syncpay?.clientSecret;
+        const clientId = process.env.SYNCPAY_CLIENT_ID;
+        const clientSecret = process.env.SYNCPAY_CLIENT_SECRET;
 
         if (!clientId || !clientSecret) {
             console.error('[Auth] Credenciais não configuradas');
-            return errorResponse('Credenciais da API não configuradas', 500, 'syncpay.clientId ou syncpay.clientSecret não definidos');
+            return errorResponse('Credenciais da API não configuradas', 500, 'SYNCPAY_CLIENT_ID ou SYNCPAY_CLIENT_SECRET não definidos');
         }
-        
+
         const authData = {
             client_id: clientId,
             client_secret: clientSecret,

--- a/netlify/functions/gateways.js
+++ b/netlify/functions/gateways.js
@@ -26,16 +26,16 @@ exports.handler = async (event, context) => {
                     // Testar configuração dos gateways
                     const gateways = paymentGateway.getAvailableGateways();
                     const currentGateway = paymentGateway.getCurrentGateway();
-                    
+
                     return successResponse({
                         message: 'Configuração dos gateways',
                         current_gateway: currentGateway,
                         gateways: gateways,
                         config_status: {
-                            pushinpay_token: cfg.pushinpay?.token ? 'Configurado' : 'Não configurado',
-                            pushinpay_environment: cfg.environment || 'production',
-                            syncpay_client_id: cfg.syncpay?.clientId ? 'Configurado' : 'Não configurado',
-                            syncpay_client_secret: cfg.syncpay?.clientSecret ? 'Configurado' : 'Não configurado'
+                            pushinpay_token: process.env.PUSHINPAY_TOKEN ? 'Configurado' : 'Não configurado',
+                            pushinpay_environment: process.env.PUSHINPAY_ENVIRONMENT || cfg.environment || 'production',
+                            syncpay_client_id: process.env.SYNCPAY_CLIENT_ID ? 'Configurado' : 'Não configurado',
+                            syncpay_client_secret: process.env.SYNCPAY_CLIENT_SECRET ? 'Configurado' : 'Não configurado'
                         }
                     });
                 } else {

--- a/public/index.html
+++ b/public/index.html
@@ -917,7 +917,6 @@ window.pixDebug = {
         if (window.SYNCPAY_CONFIG) {
             console.log('📋 Configuração SYNCPAY:', {
                 client_id: !!window.SYNCPAY_CONFIG.client_id,
-                client_secret: !!window.SYNCPAY_CONFIG.client_secret,
                 plans: !!window.SYNCPAY_CONFIG.plans
             });
         }
@@ -1016,8 +1015,6 @@ setTimeout(() => {
 <!-- <button id="authButton">Obter Token</button> -->
   <script>
     window.SYNCPAY_CONFIG = window.SYNCPAY_CONFIG || {};
-    window.SYNCPAY_CONFIG.client_id = window.SYNCPAY_CONFIG.client_id || "fixed-client-id";
-    window.SYNCPAY_CONFIG.client_secret = window.SYNCPAY_CONFIG.client_secret || "fixed-client-secret";
     if (!window.SYNCPAY_CONFIG.plans) {
       window.SYNCPAY_CONFIG.plans = {
         monthly: {
@@ -1091,10 +1088,7 @@ setTimeout(() => {
 
     <!-- Configuração SYNCPAY -->
     <script>
-        window.SYNCPAY_CONFIG = {
-            client_id: "708ddc0b-357d-4548-b158-615684caa616",
-            client_secret: "c08d40e5-3049-48c9-85c0-fd3cc6ca502c"
-        };
+        window.SYNCPAY_CONFIG = window.SYNCPAY_CONFIG || {};
     </script>
 
     <!-- Carregamento do authProxyClient.js -->

--- a/public/js/authProxyClient.js
+++ b/public/js/authProxyClient.js
@@ -19,29 +19,8 @@
         isAuthenticating = true;
         console.log('🔐 Iniciando autenticação SyncPay...');
 
-        // 1. Validar se as credenciais existem
-        if (!window.SYNCPAY_CONFIG) {
-            alert('❌ ERRO: Configuração SYNCPAY_CONFIG não encontrada!');
-            console.error('SYNCPAY_CONFIG não está definida');
-            isAuthenticating = false;
-            return;
-        }
-
-        const { client_id, client_secret } = window.SYNCPAY_CONFIG;
-
-        if (!client_id || !client_secret) {
-            alert('❌ ERRO: client_id ou client_secret não configurados!\n\nVerifique o arquivo config.js');
-            console.error('Credenciais ausentes:', { client_id: !!client_id, client_secret: !!client_secret });
-            isAuthenticating = false;
-            return;
-        }
-
-        console.log('✅ Credenciais validadas com sucesso');
-
-        // 2. Preparar dados da requisição
+        // 1. Preparar dados da requisição (credenciais são fornecidas pelo backend)
         const authData = {
-            client_id: client_id,
-            client_secret: client_secret,
             '01K1259MAXE0TNRXV2C2WQN2MV': 'auth_request_' + Date.now() // Campo obrigatório com timestamp
         };
 

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -15,8 +15,6 @@
     }
     window.APP_CONFIG = cfg;
     window.SYNCPAY_CONFIG = window.SYNCPAY_CONFIG || {};
-    window.SYNCPAY_CONFIG.client_id = cfg.syncpay?.clientId;
-    window.SYNCPAY_CONFIG.client_secret = cfg.syncpay?.clientSecret;
     window.SYNCPAY_CONFIG.plans = cfg.plans || {};
     window.PUSHINPAY_CONFIG = cfg.pushinpay || {};
 

--- a/public/js/exemplo-uso-syncpay.js
+++ b/public/js/exemplo-uso-syncpay.js
@@ -193,7 +193,7 @@
                     phone: '11987654321'
                 },
                 split: [
-                    { percentage: 100, user_id: '708ddc0b-357d-4548-b158-615684caa616' }
+                    { percentage: 100, user_id: 'SEU_CLIENT_ID_SYNCPAY_AQUI' }
                 ]
             };
             
@@ -276,7 +276,7 @@
                     phone: '11876543210'
                 },
                 split: [
-                    { percentage: 100, user_id: '708ddc0b-357d-4548-b158-615684caa616' }
+                    { percentage: 100, user_id: 'SEU_CLIENT_ID_SYNCPAY_AQUI' }
                 ]
             };
             

--- a/public/js/syncpay-integration.js
+++ b/public/js/syncpay-integration.js
@@ -49,21 +49,8 @@
             return authToken;
         }
 
-        // Validar configuração
-        if (!window.SYNCPAY_CONFIG) {
-            throw new Error('Configuração SYNCPAY_CONFIG não encontrada');
-        }
-
-        const { client_id, client_secret } = window.SYNCPAY_CONFIG;
-
-        if (!client_id || !client_secret) {
-            throw new Error('client_id ou client_secret não configurados');
-        }
-
-        // Preparar dados da requisição
+        // Preparar dados da requisição (credenciais são injetadas no backend)
         const authData = {
-            client_id: client_id,
-            client_secret: client_secret,
             '01K1259MAXE0TNRXV2C2WQN2MV': 'auth_request_' + Date.now()
         };
 
@@ -612,7 +599,7 @@
                     phone: '11987654321'
                 },
                 split: [
-                    { percentage: 100, user_id: '708ddc0b-357d-4548-b158-615684caa616' }
+                    { percentage: 100, user_id: 'SEU_CLIENT_ID_SYNCPAY_AQUI' }
                 ]
             };
 

--- a/public/js/test-popup.js
+++ b/public/js/test-popup.js
@@ -60,7 +60,6 @@ function checkConfiguration() {
     if (window.SYNCPAY_CONFIG) {
         console.log('✅ SYNCPAY_CONFIG:', {
             client_id: !!window.SYNCPAY_CONFIG.client_id,
-            client_secret: !!window.SYNCPAY_CONFIG.client_secret,
             plans: !!window.SYNCPAY_CONFIG.plans
         });
         

--- a/pushinpayApi.js
+++ b/pushinpayApi.js
@@ -3,12 +3,13 @@ const { getConfig } = require('./loadConfig');
 
 // Carregar configurações dinâmicas
 const cfg = getConfig();
-const PUSHINPAY_TOKEN = cfg.pushinpay?.token || '';
+const PUSHINPAY_TOKEN = process.env.PUSHINPAY_TOKEN || '';
+const ENVIRONMENT = process.env.PUSHINPAY_ENVIRONMENT || cfg.environment || 'production';
 
 // URLs conforme documentação oficial
 const API_BASE_PROD = 'https://api.pushinpay.com.br';
 const API_BASE_SANDBOX = 'https://api-sandbox.pushinpay.com.br';
-const API_BASE = cfg.environment === 'sandbox' ? API_BASE_SANDBOX : API_BASE_PROD;
+const API_BASE = ENVIRONMENT === 'sandbox' ? API_BASE_SANDBOX : API_BASE_PROD;
 
 async function pushinpayGet(endpoint, config = {}) {
   return axios.get(`${API_BASE}${endpoint}`, {
@@ -170,8 +171,8 @@ async function listPayments(filters = {}) {
 // Função para verificar configuração e ambiente
 function getEnvironmentInfo() {
   const cfg = getConfig();
-  const token = cfg.pushinpay?.token;
-  const environment = cfg.environment || 'production';
+  const token = process.env.PUSHINPAY_TOKEN;
+  const environment = process.env.PUSHINPAY_ENVIRONMENT || cfg.environment || 'production';
   return {
     environment,
     api_base: environment === 'sandbox' ? API_BASE_SANDBOX : API_BASE_PROD,

--- a/server.js
+++ b/server.js
@@ -83,18 +83,17 @@ app.post('/api/auth-token', async (req, res) => {
         const extraField = req.body['01K1259MAXE0TNRXV2C2WQN2MV'] || 'valor';
         
         // Verificar se as credenciais estão disponíveis
-        const cfg = getConfig();
-        const clientId = cfg.syncpay?.clientId;
-        const clientSecret = cfg.syncpay?.clientSecret;
+        const clientId = process.env.SYNCPAY_CLIENT_ID;
+        const clientSecret = process.env.SYNCPAY_CLIENT_SECRET;
 
         if (!clientId || !clientSecret) {
             console.error('[Auth] Credenciais não configuradas');
             return res.status(500).json({
                 message: 'Credenciais da API não configuradas',
-                error: 'syncpay.clientId ou syncpay.clientSecret não definidos'
+                error: 'SYNCPAY_CLIENT_ID ou SYNCPAY_CLIENT_SECRET não definidos'
             });
         }
-        
+
         const authData = {
             client_id: clientId,
             client_secret: clientSecret,
@@ -471,10 +470,10 @@ app.get('/api/gateways/test', (req, res) => {
             current_gateway: currentGateway,
             gateways: gateways,
             config_status: {
-                pushinpay_token: cfg.pushinpay?.token ? 'Configurado' : 'Não configurado',
-                pushinpay_environment: cfg.environment || 'production',
-                syncpay_client_id: cfg.syncpay?.clientId ? 'Configurado' : 'Não configurado',
-                syncpay_client_secret: cfg.syncpay?.clientSecret ? 'Configurado' : 'Não configurado'
+                pushinpay_token: process.env.PUSHINPAY_TOKEN ? 'Configurado' : 'Não configurado',
+                pushinpay_environment: process.env.PUSHINPAY_ENVIRONMENT || cfg.environment || 'production',
+                syncpay_client_id: process.env.SYNCPAY_CLIENT_ID ? 'Configurado' : 'Não configurado',
+                syncpay_client_secret: process.env.SYNCPAY_CLIENT_SECRET ? 'Configurado' : 'Não configurado'
             }
         });
     } catch (error) {

--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
   ],
   "env": {
     "NODE_ENV": "production",
-    "SYNCPAY_CLIENT_ID": "708ddc0b-357d-4548-b158-615684caa616",
-    "SYNCPAY_CLIENT_SECRET": "c08d40e5-3049-48c9-85c0-fd3cc6ca502c"
+    "SYNCPAY_CLIENT_ID": "",
+    "SYNCPAY_CLIENT_SECRET": ""
   }
 }

--- a/webhookHandler.js
+++ b/webhookHandler.js
@@ -10,7 +10,7 @@ const { getConfig } = require('./loadConfig');
 class WebhookHandler {
     constructor() {
         const cfg = getConfig();
-        this.webhookSecret = cfg.webhook?.secret || 'default_secret';
+        this.webhookSecret = process.env.WEBHOOK_SECRET || cfg.webhook?.secret || 'default_secret';
     }
 
     /**


### PR DESCRIPTION
## Summary
- load environment variables and strip secrets from `app-config.json`
- use `process.env` for SyncPay and PushinPay credentials across server and functions
- document required keys for deployment on Netlify

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7873833e8832aa21957aeff54a9a9